### PR TITLE
fix: hoc context ref is not deleted

### DIFF
--- a/src/hoc/with-touchable-handler.tsx
+++ b/src/hoc/with-touchable-handler.tsx
@@ -116,7 +116,7 @@ const withTouchableHandler = <T,>(
       } as any;
 
       return () => {
-        delete ref.current?.[id];
+        delete ref.current?.[`id:${id}`];
       };
     }, [id, isPointInPath, onActive, onEnd, onStart, ref, touchablePath]);
 


### PR DESCRIPTION
Fixes a typo in the touchable hoc that would not correctly delete records out of the context by id.

Fixes #7