### PR TITLE
fix: reanimated crashes on the latest version, example app crashes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ export default function App() {
         y: cy.value,
       }
     },
-    onActive: ({ translationX, translationY }, context) => {
+    onActive: ({ translationX, translationY }) => {
       'worklet';
       cx.value = context.value.x + translationX;
       cy.value = context.value.y + translationY;

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -49,12 +49,14 @@ function App() {
 
   const rectGesture = useGestureHandler({
     onStart: () => {
+      'worklet';
       rectContext.value = {
         x: rectX.value,
         y: rectY.value,
       };
     },
     onActive: ({ translationX, translationY }) => {
+      'worklet';
       rectX.value = rectContext.value.x + translationX;
       rectY.value = rectContext.value.y + translationY;
     },

--- a/src/canvas/canvas.tsx
+++ b/src/canvas/canvas.tsx
@@ -5,7 +5,7 @@ import {
   GestureDetector,
   PanGesture,
 } from 'react-native-gesture-handler';
-import Animated, { useSharedValue } from 'react-native-reanimated';
+import { useSharedValue } from 'react-native-reanimated';
 
 import {
   TouchHandlerContext,
@@ -18,8 +18,6 @@ type TouchableCanvasProps = CanvasProps & {
   panGesture?: PanGesture;
   timeoutBeforeCollectingRefs?: number; // default 100
 };
-
-const AnimatedSkiaCanvas = Animated.createAnimatedComponent(SkiaCanvas);
 
 const Canvas: React.FC<TouchableCanvasProps> = ({
   children,
@@ -54,6 +52,7 @@ const Canvas: React.FC<TouchableCanvasProps> = ({
 
   const mainGesture = panGesture
     .onBegin((event) => {
+      'worklet';
       const keys = Object.keys(loadedRefs);
       for (let i = 0; i < keys.length; i++) {
         const key = keys[i] as string;
@@ -66,6 +65,7 @@ const Canvas: React.FC<TouchableCanvasProps> = ({
       }
     })
     .onUpdate((event) => {
+      'worklet';
       const activatedKey = activeKey.value.find((key) =>
         key.includes(event.handlerTag.toString())
       );
@@ -83,6 +83,7 @@ const Canvas: React.FC<TouchableCanvasProps> = ({
       return touchableItem?.onActive?.(event);
     })
     .onFinalize((event) => {
+      'worklet';
       const activatedKey = activeKey.value.find((key) =>
         key.includes(event.handlerTag.toString())
       );
@@ -108,11 +109,11 @@ const Canvas: React.FC<TouchableCanvasProps> = ({
 
   return (
     <GestureDetector gesture={mainGesture}>
-      <AnimatedSkiaCanvas {...props}>
+      <SkiaCanvas {...props}>
         <TouchHandlerContext.Provider value={touchableRefs}>
           {children}
         </TouchHandlerContext.Provider>
-      </AnimatedSkiaCanvas>
+      </SkiaCanvas>
     </GestureDetector>
   );
 };


### PR DESCRIPTION
## Description

This PR removes unnecessary `Animated.createAnimatedComponent` call for the `Canvas` component, which causes crashes on the latest `react-native-reanimated` version. Since it is not necessary (it takes neither animated style, nor animated props), it can be removed.

I also added missing `'worklet'` keywords in gesture handler functions in the example app which were missing and caused crashes for the rect component.

I bumped `react-native-gesture-handler` and added `'worklet'` keyword to callbacks declared on the gesture in the `src/canvas/canvas.tsx` component as gesture handler started to show warnings in the latest version when `'worklet'` is missing.

## Repro

You can see the issues I described in the [repro](https://github.com/MatiPl01/react-native-skia-gesture-issue) on this repository (the `main` branch).
Patched library with changes from this PR is included in the `patched` branch.